### PR TITLE
Migrate documentation to GitHub Pages 

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,46 @@
+# Copyright 2021 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Build and Deploy Documentation
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Build-Documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Get Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.10'
+
+      - name: Build Documentation
+        run: |
+          python3 -m venv virt_env
+          source virt_env/bin/activate
+          cd docs
+          pip3 install -r requirements.txt
+          make html
+          deactivate
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = CMakeTest
+SPHINXPROJ    =
 SOURCEDIR     = source
 BUILDDIR      = build
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
Migrates documentation from Read the Docs to GitHub Pages to be consistent with the rest of CPP. I just copied the .github/workflows/deploy_docs.yml file from the CMakePPLang repository with no changes. Closes #3.

This PR will:

- [x] Create a workflow to automatically generate and deploy documentation to GitHub Pages in the `gh-pages` branch.
- [x] Create `docs/requirements.txt` so the dependencies needed to build the docs can be installed in the workflow.

After this PR is merged:

- [ ] Turn on GitHub Pages hosting from the `gh-pages` branch in the repo settings.
- [ ] Add https://cmakepp.github.io/CMakeDev to the "About" section of this repository.
- [x] Fix the documentation link from https://cmakepp.github.io/.